### PR TITLE
bump to version 0.2.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.2.0" %}
+{% set version = "0.2.1" %}
 
 package:
   name: mpl-probscale


### PR DESCRIPTION
New release now has bootstrapped confidence intervals around the best-fit lines
